### PR TITLE
Notebook SDK

### DIFF
--- a/nodejs_poc/toolbox_functions.js
+++ b/nodejs_poc/toolbox_functions.js
@@ -1,0 +1,38 @@
+// Engine generate command module
+'use strict';
+
+var imageName = 'marvinaiplatform/marvin-automl:0.0.1'
+var containerName = 'docker-api-test'
+
+const {Docker} = require('node-docker-api');
+
+// Log capture function
+const promisifyStream = stream => new Promise((resolve, reject) => {
+  stream.on('data', data => console.log(data.toString()))
+  stream.on('end', resolve)
+  stream.on('error', reject)
+});
+
+const docker = new Docker({ socketPath: '/var/run/docker.sock' });
+let _container;
+
+// Start container, run engine generate command and capture logs
+docker.container.create({
+  Image: imageName,
+  Cmd: [ '/bin/bash', '-c', 'tail -f /var/log/dmesg' ],
+  name: containerName
+})
+  .then(container => container.start())
+  .then(container => {
+  	_container = container
+  	return container.exec.create({
+  		AttachStdout: true,
+  		AttachStderr: true,
+  		Cmd: ['workon python-toolbox-env', 'marvin engine-generate']
+  	})
+  })
+  .then(stream => promisifyStream(stream))
+  .catch(error => console.log(error));
+
+  ### TO DO ###
+  // User instructions for inserting project name, maintainer name and etc....

--- a/nodejs_poc/toolbox_functions.js
+++ b/nodejs_poc/toolbox_functions.js
@@ -31,6 +31,9 @@ docker.container.create({
   		Cmd: ['workon python-toolbox-env', 'marvin engine-generate']
   	})
   })
+  .then(exec => {
+    return exec.start({ Detach: false })
+  })
   .then(stream => promisifyStream(stream))
   .catch(error => console.log(error));
 

--- a/nodejs_poc/toolbox_functions.js
+++ b/nodejs_poc/toolbox_functions.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var imageName = 'marvinaiplatform/marvin-automl:0.0.1'
-var containerName = 'docker-api-test'
+var containerName = 'docker-api-test13'
 
 const {Docker} = require('node-docker-api');
 
@@ -26,16 +26,13 @@ docker.container.create({
   .then(container => {
   	_container = container
   	return container.exec.create({
-  		AttachStdout: true,
-  		AttachStderr: true,
-  		Cmd: ['workon python-toolbox-env', 'marvin engine-generate']
-  	})
+      	  AttachStdout: true,
+      	  AttachStderr: true,
+      	  Cmd: [ '/bin/bash', '-c', 'source /usr/local/bin/virtualenvwrapper.sh ; workon marvin-engine-env ; cd /opt/marvin/engine/ ; marvin notebook --allow-root -p 9999 ' ]
+    })
   })
   .then(exec => {
     return exec.start({ Detach: false })
   })
   .then(stream => promisifyStream(stream))
   .catch(error => console.log(error));
-
-  ### TO DO ###
-  // User instructions for inserting project name, maintainer name and etc....

--- a/nodejs_poc/toolbox_functions.js
+++ b/nodejs_poc/toolbox_functions.js
@@ -1,38 +1,41 @@
 // Engine generate command module
 'use strict';
 
+const {Docker} = require('node-docker-api');
+const docker = new Docker({ socketPath: '/var/run/docker.sock' });
+
 var imageName = 'marvinaiplatform/marvin-automl:0.0.1'
 var containerName = 'docker-api-test13'
 
-const {Docker} = require('node-docker-api');
+function notebookSDK(imageName, containerName) {
 
-// Log capture function
-const promisifyStream = stream => new Promise((resolve, reject) => {
-  stream.on('data', data => console.log(data.toString()))
-  stream.on('end', resolve)
-  stream.on('error', reject)
-});
+	let _container;
 
-const docker = new Docker({ socketPath: '/var/run/docker.sock' });
-let _container;
+	// Log capture
+	const promisifyStream = stream => new Promise((resolve, reject) => {
+		stream.on('data', data => console.log(data.toString()))
+		stream.on('end', resolve)
+		stream.on('error', reject)
+	});
 
-// Start container, run engine generate command and capture logs
-docker.container.create({
-  Image: imageName,
-  Cmd: [ '/bin/bash', '-c', 'tail -f /var/log/dmesg' ],
-  name: containerName
-})
-  .then(container => container.start())
-  .then(container => {
-  	_container = container
-  	return container.exec.create({
-      	  AttachStdout: true,
-      	  AttachStderr: true,
-      	  Cmd: [ '/bin/bash', '-c', 'source /usr/local/bin/virtualenvwrapper.sh ; workon marvin-engine-env ; cd /opt/marvin/engine/ ; marvin notebook --allow-root -p 9999 ' ]
-    })
-  })
-  .then(exec => {
-    return exec.start({ Detach: false })
-  })
-  .then(stream => promisifyStream(stream))
-  .catch(error => console.log(error));
+	// Start container, run engine generate command and capture logs
+	docker.container.create({
+		Image: imageName,
+		Cmd: [ '/bin/bash', '-c', 'tail -f /var/log/dmesg' ],
+		name: containerName
+	})
+	.then(container => container.start())
+	.then(container => {
+		_container = container
+		return container.exec.create({
+			AttachStdout: true,
+			AttachStderr: true,
+			Cmd: [ '/bin/bash', '-c', 'source /usr/local/bin/virtualenvwrapper.sh ; workon marvin-engine-env ; cd /opt/marvin/engine/ ; marvin notebook --allow-root -p 9999 ' ]
+		})
+	})
+	.then(exec => {
+		return exec.start({ Detach: false })
+	})
+	.then(stream => promisifyStream(stream))
+	.catch(error => console.log(error));
+}

--- a/nodejs_poc/toolbox_functions.js
+++ b/nodejs_poc/toolbox_functions.js
@@ -3,9 +3,10 @@
 
 const {Docker} = require('node-docker-api');
 const docker = new Docker({ socketPath: '/var/run/docker.sock' });
+const repl = require('repl');
 
-var imageName = 'marvinaiplatform/marvin-automl:0.0.1'
-var containerName = 'docker-api-test13'
+var imageName = 'marvinaiplatform/marvin-automl:0.0.1';
+var containerName = 'docker-api-test13';
 
 function notebookSDK(imageName, containerName) {
 
@@ -39,3 +40,9 @@ function notebookSDK(imageName, containerName) {
 	.then(stream => promisifyStream(stream))
 	.catch(error => console.log(error));
 }
+
+var replServer = repl.start({
+	prompt: "marvin >",
+});
+
+replServer.context.engine_generate = notebookSDK(imageName, containerName)

--- a/nodejs_poc/toolbox_functions.js
+++ b/nodejs_poc/toolbox_functions.js
@@ -5,10 +5,7 @@ const {Docker} = require('node-docker-api');
 const docker = new Docker({ socketPath: '/var/run/docker.sock' });
 const repl = require('repl');
 
-var imageName = 'marvinaiplatform/marvin-automl:0.0.1';
-var containerName = 'docker-api-test13';
-
-function notebookSDK(imageName, containerName) {
+function notebookSDK() {
 
 	let _container;
 
@@ -21,9 +18,9 @@ function notebookSDK(imageName, containerName) {
 
 	// Start container, run engine generate command and capture logs
 	docker.container.create({
-		Image: imageName,
+		Image: 'marvinaiplatform/marvin-automl:0.0.1',
 		Cmd: [ '/bin/bash', '-c', 'tail -f /var/log/dmesg' ],
-		name: containerName
+		name: 'docker-api-test'
 	})
 	.then(container => container.start())
 	.then(container => {
@@ -42,7 +39,7 @@ function notebookSDK(imageName, containerName) {
 }
 
 var replServer = repl.start({
-	prompt: "marvin >",
+	prompt: "marvin > ",
 });
 
-replServer.context.engine_generate = notebookSDK(imageName, containerName)
+replServer.context.notebook = notebookSDK


### PR DESCRIPTION
Notebook command added to toolbox function.

The Docker image used in code is temporary, it should be parameterized for main function call.

For tests:

Run the toolbox_functions.js file directly to start marvin repl -> node toolbox_functions.js.

Use cmd 'notebook()' to bring up Jupyter notebook.

I have tried to avoid '()' at the end of cmd, but I did not find a way, here is an example:
https://www.hexacta.com/2015/10/13/highway-to-shell-with-nodejs/
